### PR TITLE
Add Beta-Bernoulli inference exercise

### DIFF
--- a/content/genjax/05_beta_bernoulli.md
+++ b/content/genjax/05_beta_bernoulli.md
@@ -1,0 +1,105 @@
++++
+date = "2025-12-24"
+title = "Beta-Bernoulli: Your First Inference"
+weight = 6
++++
+
+## From Simulation to Inference
+
+So far, we've been **generating** data from models. But the real power of probabilistic programming is **inference**: given observed data, what can we learn about the hidden variables?
+
+This is like detective work: we see the evidence (coin flips), and we want to deduce the cause (the coin's bias).
+
+---
+
+## The Beta-Bernoulli Model
+
+Imagine a coin with unknown bias $p$. We don't know if it's fair!
+
+**The generative story:**
+1. Nature picks a bias $p$ from a Beta(α, β) distribution
+2. The coin is flipped, landing heads with probability $p$
+3. We observe the outcome
+
+```python
+from genjax import gen, beta, flip
+
+@gen
+def beta_bernoulli(α, β):
+    p = beta(α, β) @ "p"  # Unknown bias
+    v = flip(p) @ "v"     # Observed flip
+    return v
+```
+
+The `@ "p"` and `@ "v"` are **addresses**—named random choices we can later constrain or query.
+
+---
+
+## The Inference Question
+
+> "Given that we observed heads, what's our belief about $p$?"
+
+This is **conditioning**: we fix `v = True` and ask what values of `p` are consistent with this observation.
+
+Mathematically, we want:
+$$P(p \mid v = \text{True})$$
+
+This is the **posterior distribution** over the coin's bias.
+
+---
+
+## Inference in GenJAX
+
+GenJAX provides inference algorithms that estimate posteriors. Here's the pattern:
+
+```python
+from genjax import Target, ChoiceMap
+from genjax.inference.smc import ImportanceK
+
+# Define what we want to infer
+posterior_target = Target(
+    beta_bernoulli,          # the model
+    (2.0, 2.0),              # prior parameters
+    ChoiceMap.d({"v": True}), # observation
+)
+
+# Run importance sampling with 50 particles
+alg = ImportanceK(posterior_target, k_particles=50)
+```
+
+---
+
+## Try It Yourself
+
+Open the companion notebook to:
+
+1. **Simulate** from the model and examine traces
+2. **Run inference** to estimate $p$ given observations
+3. **Experiment** with different priors (α, β values)
+4. **Observe** how more data sharpens our beliefs
+
+{{% notice style="info" title="Companion Notebook" %}}
+📓 [`beta_bernoulli.ipynb`](/notebooks/beta_bernoulli.ipynb) — Full working code with exercises
+{{% /notice %}}
+
+---
+
+## Key Insights
+
+| Concept | What It Means |
+|---------|---------------|
+| **Prior** | Beta(α, β) — our belief before seeing data |
+| **Likelihood** | Bernoulli(p) — how data is generated |
+| **Posterior** | Updated belief after seeing data |
+| **Inference** | Computing the posterior from prior + data |
+
+---
+
+## What's Next?
+
+With Beta-Bernoulli mastered, you're ready for:
+- **Multiple observations** — what if we see 10 flips?
+- **More complex models** — Gaussian mixtures, hierarchical models
+- **Different inference algorithms** — MCMC, variational inference
+
+The core pattern stays the same: define a model, specify observations, run inference.

--- a/notebooks/beta_bernoulli.ipynb
+++ b/notebooks/beta_bernoulli.ipynb
@@ -1,0 +1,232 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a69a4027",
+   "metadata": {},
+   "source": [
+    "# GenJAX Basics: Beta-Bernoulli\n",
+    "\n",
+    "First exploration of generative functions and inference in GenJAX.\n",
+    "Based on the quickstart example from genjax.gen.dev"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "6d47b885",
+   "metadata": {
+    "lines_to_next_cell": 1
+   },
+   "outputs": [],
+   "source": [
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "import genjax\n",
+    "from genjax import beta, flip, gen, Target, ChoiceMap\n",
+    "from genjax.inference.smc import ImportanceK"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e800b8c",
+   "metadata": {},
+   "source": [
+    "## 1. Define a Generative Model\n",
+    "\n",
+    "A generative function is a computational object representing a probability distribution.\n",
+    "The `@gen` decorator marks this as a generative function.\n",
+    "\n",
+    "This model:\n",
+    "1. Draws `p` from a Beta(α, β) distribution\n",
+    "2. Flips a coin with probability `p`\n",
+    "3. Returns the coin flip result\n",
+    "\n",
+    "The `@ \"p\"` and `@ \"v\"` are **addresses** - named random choices we can constrain/observe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "798799f7",
+   "metadata": {
+    "lines_to_next_cell": 1
+   },
+   "outputs": [],
+   "source": [
+    "@gen\n",
+    "def beta_bernoulli(α, β):\n",
+    "    p = beta(α, β) @ \"p\"  # Draw p from Beta distribution\n",
+    "    v = flip(p) @ \"v\"     # Flip coin with probability p\n",
+    "    return v"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a8abae4e",
+   "metadata": {},
+   "source": [
+    "## 2. Understanding Traces\n",
+    "\n",
+    "When we run a generative function, we get a **trace** - a record of all random choices made."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "7fde085d",
+   "metadata": {
+    "lines_to_next_cell": 1
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Return value: True\n",
+      "Choices: Static({'v': Choice(v=<jax.Array(True, dtype=bool)>), 'p': Choice(v=<jax.Array(0.76402074, dtype=float32)>)})\n",
+      "  p = 0.7640207409858704\n",
+      "  v = True\n",
+      "Log probability: -0.19057175517082214\n"
+     ]
+    }
+   ],
+   "source": [
+    "key = jax.random.key(42)\n",
+    "trace = beta_bernoulli.simulate(key, (2.0, 2.0))\n",
+    "\n",
+    "print(f\"Return value: {trace.get_retval()}\")\n",
+    "print(f\"Choices: {trace.get_choices()}\")\n",
+    "print(f\"  p = {trace.get_choices()['p']}\")\n",
+    "print(f\"  v = {trace.get_choices()['v']}\")\n",
+    "print(f\"Log probability: {trace.get_score()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "226f5914",
+   "metadata": {},
+   "source": [
+    "## 3. Inference: What is p given we observed v=True?\n",
+    "\n",
+    "This is the key question in probabilistic programming:\n",
+    "Given observations, what are the latent variables?\n",
+    "\n",
+    "We create a **Target** (posterior) by specifying:\n",
+    "- The model\n",
+    "- Arguments to the model  \n",
+    "- Constraints (observations)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "04b5c0e9",
+   "metadata": {
+    "lines_to_next_cell": 1
+   },
+   "outputs": [],
+   "source": [
+    "@jax.jit\n",
+    "def run_inference(obs: bool):\n",
+    "    # Create a posterior target\n",
+    "    posterior_target = Target(\n",
+    "        beta_bernoulli,          # the model\n",
+    "        (2.0, 2.0),              # arguments (α, β)\n",
+    "        ChoiceMap.d({\"v\": obs}), # constraint: we observed v\n",
+    "    )\n",
+    "    \n",
+    "    # Use Sampling Importance Resampling (SIR) with K=50 particles\n",
+    "    alg = ImportanceK(posterior_target, k_particles=50)\n",
+    "    \n",
+    "    # Run 50 independent trials\n",
+    "    key = jax.random.key(314)\n",
+    "    sub_keys = jax.random.split(key, 50)\n",
+    "    \n",
+    "    # vmap runs inference in parallel across all keys\n",
+    "    _, p_chm = jax.vmap(alg.random_weighted, in_axes=(0, None))(\n",
+    "        sub_keys, posterior_target\n",
+    "    )\n",
+    "    \n",
+    "    # Return mean estimate of p\n",
+    "    return jnp.mean(p_chm[\"p\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "64df23a8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "E[p | v=True]  = 0.5646\n",
+      "E[p | v=False] = 0.4338\n"
+     ]
+    }
+   ],
+   "source": [
+    "p_given_true = run_inference(True)\n",
+    "p_given_false = run_inference(False)\n",
+    "\n",
+    "print(f\"E[p | v=True]  = {p_given_true:.4f}\")\n",
+    "print(f\"E[p | v=False] = {p_given_false:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "516bd9bd",
+   "metadata": {},
+   "source": [
+    "## Key Concepts Learned\n",
+    "\n",
+    "1. **Generative functions** (`@gen`) define probability distributions\n",
+    "2. **Addresses** (`@ \"name\"`) label random choices for later reference\n",
+    "3. **Traces** record all choices and their probabilities\n",
+    "4. **Targets** specify inference problems (model + constraints)\n",
+    "5. **Inference algorithms** (like ImportanceK) estimate posterior distributions\n",
+    "6. **JAX integration**: Everything is JIT-compilable and vmap-able"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6fad2bc2",
+   "metadata": {},
+   "source": [
+    "## Exercises\n",
+    "\n",
+    "1. Try different α, β values - how does the prior affect the posterior?\n",
+    "2. What happens with more/fewer particles?\n",
+    "3. What if we observe multiple coin flips?"
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "-all",
+   "main_language": "python",
+   "notebook_metadata_filter": "-all"
+  },
+  "kernelspec": {
+   "display_name": "prob-comp-learn",
+   "language": "python",
+   "name": "prob-comp-learn"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

This PR adds a **Beta-Bernoulli inference exercise** that bridges the gap between simulation (chapters 1-4) and complex models (chapter 6). It provides learners with their first hands-on experience with probabilistic inference in GenJAX.

## What's Added

### 1. Hugo Content Page (`content/genjax/05_beta_bernoulli.md`)

A conceptual introduction that:
- Explains the transition from simulation to inference
- Introduces the Beta-Bernoulli conjugate model
- Shows the GenJAX `Target` and `ImportanceK` pattern
- Links to the companion notebook

### 2. Interactive Notebook (`notebooks/beta_bernoulli.ipynb`)

A hands-on notebook covering:
- Defining generative functions with `@gen`
- Using addresses (`@ "name"`) for random choices
- Examining traces and their log probabilities
- Running importance sampling inference
- Estimating posteriors from observations

## Learning Path Integration

The new content fits naturally in the existing sequence:

```
00 Getting Started
01 Python Basics  
02 First Model (simulation)
03 Traces
04 Conditioning
05 Beta-Bernoulli ← NEW (first inference!)
06 Building Models
```

## Key Concepts Covered

| Concept | Description |
|---------|-------------|
| Prior | Beta(α, β) distribution over coin bias |
| Likelihood | Bernoulli observation model |
| Posterior | Updated belief after seeing data |
| Importance Sampling | Inference algorithm (ImportanceK) |

## Exercises Included

1. Experiment with different prior parameters (α, β)
2. Vary the number of particles in importance sampling
3. Extend to multiple observations

---

Happy to make any adjustments to better fit the course style!